### PR TITLE
Remove: package.json: private key

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "gitevents-jobs",
   "version": "0.0.1",
-  "private": false,
   "main": "index.js",
   "repository": "https://github.com/gitevents/gitevents-jobs.git",
   "scripts": {


### PR DESCRIPTION
I think you do not need add `private: false` in package.json because this purpose is to prevent accidental publication of private repositories.

ref: https://docs.npmjs.com/files/package.json#private
